### PR TITLE
[Bug] Fix minor parsing error when ipb=0 in &pb

### DIFF
--- a/GMXMMPBSA/amber_outputs.py
+++ b/GMXMMPBSA/amber_outputs.py
@@ -753,7 +753,14 @@ class PBout(AmberOutput):
                 self['1-4 VDW'][self.frame_idx] = conv_float(words[3])
                 self['1-4 EEL'][self.frame_idx] = conv_float(words[7])
                 words = outfile.readline().split()
-                self['ENPOLAR'][self.frame_idx] = conv_float(words[2])
+
+                # electrostatic solvation free energy will not report in amber ouput
+                # when `ipb=0`. in such case, set it as 0 would be reasonable
+                if self.INPUT['pb']['ipb'] == 0:
+                    self['ENPOLAR'][self.frame_idx] = 0
+                else:
+                    self['ENPOLAR'][self.frame_idx] = conv_float(words[2])
+
                 if self.INPUT['pb']['inp'] == 2 and not self.apbs:
                     self['EDISPER'][self.frame_idx] = conv_float(words[5])
                 self.frame_idx += 1


### PR DESCRIPTION
When `ipb` is set as `0` along with AmberTools==21.12 (in which the version of the bundled `sander` is 20.0), the `ENPOLAR` would not be available, as no electrostatic solvation free energy is computed and reported from `sander`. The snippet of mdout is as following:

```
                    FINAL RESULTS



   NSTEP       ENERGY          RMS            GMAX         NAME    NUMBER
      1      -1.7269E+02     3.7062E+00     2.2135E+01     H1          2

 BOND    =       30.6180  ANGLE   =       91.6638  DIHED      =      387.8624
 VDWAALS =     -147.5638  EEL     =    -2568.7945  HBOND      =        0.0000
 1-4 VDW =      148.5901  1-4 EEL =     1884.9328  RESTRAINT  =        0.0000
minimization completed, ENE= -.17269112E+03 RMS= 0.370617E+01
TRAJENE: Trajectory file ended
TRAJENE: Trajene complete.
```

This patch directly assign the `ENPOLAR` term as `0` when `ipb=0`, hope you could accept this.