### PR TITLE
Add parmed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',
     keywords=['gmx_MMPBSA', 'MMPBSA', 'MMGBSA', 'GROMACS', 'AmberTools'],
-    install_requires=['pandas==1.2.2', 'seaborn<0.12', 'mpi4py>=3.1.3', 'scipy>=1.6.1', 'matplotlib>=3.5.1', 'tqdm'],
+    install_requires=['pandas==1.2.2', 'seaborn<0.12', 'mpi4py>=3.1.3', 'scipy>=1.6.1', 'matplotlib>=3.5.1', 'tqdm','parmed'],
     entry_points={
         "console_scripts": [
             "gmx_MMPBSA=GMXMMPBSA.app:gmxmmpbsa",


### PR DESCRIPTION
pip install into virtual environment does not install _parmed_

```
python3.9 -m venv
./venv/bin/pip install gmx_MMPBSA 
./venv/bin/python -c 'import parmed'

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'parmed'