### PR TITLE
Corrected _temp_top.top behaviour to accommodate asynchronous scenarios

### DIFF
--- a/GMXMMPBSA/make_top.py
+++ b/GMXMMPBSA/make_top.py
@@ -823,7 +823,7 @@ class CheckMakeTop:
         top_file = Path(top_file)
         molsect = False
 
-        with tempfile.NamedTemporaryFile(dir=top_file.parent, prefix='_temp_top', suffix='.top', mode='w') as temp_top:
+        with tempfile.NamedTemporaryFile(dir=top_file.parent, prefix='_temp_top', suffix='.top', mode='w+') as temp_top:
             # temp_top.write('; Modified by gmx_MMPBSA\n')
             # TODO: keep solvent when n-wat is implemented
             with open(top_file) as topf:

--- a/GMXMMPBSA/make_top.py
+++ b/GMXMMPBSA/make_top.py
@@ -823,7 +823,7 @@ class CheckMakeTop:
         top_file = Path(top_file)
         molsect = False
 
-        with tempfile.NamedTemporaryFile(dir=top_file.parent, prefix='_temp_top', suffix='.top', mode='w+') as temp_top:
+        with tempfile.NamedTemporaryFile(dir=top_file.parent, prefix='_temp_top', suffix='.top', mode='w', delete=False) as temp_top:
             # temp_top.write('; Modified by gmx_MMPBSA\n')
             # TODO: keep solvent when n-wat is implemented
             with open(top_file) as topf:
@@ -849,8 +849,8 @@ class CheckMakeTop:
                             continue
                     temp_top.write(line)
 
-            # read the temp topology with parmed
-            rtemp_top = parmed.gromacs.GromacsTopologyFile(temp_top.name)
+        # read the temp topology with parmed
+        rtemp_top = parmed.gromacs.GromacsTopologyFile(temp_top.name)
         # get the residues in the top from the com_ndx
         res_list = []
 
@@ -865,6 +865,9 @@ class CheckMakeTop:
 
         ranges = list2range(res_list)
         rtemp_top.strip(f"!:{','.join(ranges['string'])}")
+
+        # Clean temporal file
+        Path(temp_top.name).unlink()
         return rtemp_top
 
     def get_masks(self):


### PR DESCRIPTION
## Issue Addressed:

Encountered a `FileNotFoundError: [Errno 2] No such file or directory: '.../_temp_top.top'` error during asynchronous execution of `gmx_MMPBSA`, particularly when multiple jobs sharing the same topology file were run concurrently (e.g., using replicas).

## Solution Overview:

The issue stemmed from one job deleting the topology file before another job could access it. To mitigate this, the fix involved utilizing `tempfile.NamedTemporaryFile(dir=top_file.parent, prefix='_temp_top', suffix='.top', mode='w')`. This approach ensures the creation of a unique temporary topology file for each parallel job instance. Notably, the temporary file is generated in the directory of `top_file` to prevent recurrence of issue #299.